### PR TITLE
add sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# csr-util
+
+Small .NET 10 CLI app that uses ConsoleAppFramework and wraps `openssl` to generate private keys and PKCS#10 CSRs for local services.
+
+## Features
+
+- SDK-style .NET 10 project with Native AOT publishing enabled.
+- `csr-util.slnx` solution file.
+- EC keys by default (`prime256v1`), RSA keys on request.
+- Multiple DNS subject names are written into the CSR `subjectAltName` extension.
+- Output is standard PEM and can be imported into EasyRSA.
+
+## Usage
+
+```bash
+# EC key, default curve prime256v1
+csr-util generate app.local api.app.local
+```
+
+```bash
+# RSA key
+csr-util generate --key-type rsa --rsa-bits 3072 app.local api.app.local
+```
+
+```bash
+# Custom output directory and file prefix
+csr-util generate --output-directory ./certs --prefix app-dev app.local app.internal.local
+```
+
+Comma-separated names are also accepted:
+
+```bash
+csr-util generate app.local,api.app.local
+```
+
+Outputs:
+
+- `<prefix>.key.pem`
+- `<prefix>.csr.pem`
+
+`<prefix>` defaults to the first subject name with invalid filename characters replaced. Existing output files are not overwritten unless `--overwrite` is passed.
+
+## EasyRSA
+
+Import the generated CSR with EasyRSA:
+
+```bash
+easyrsa import-req ./certs/app-dev.csr.pem app-dev
+easyrsa sign-req server app-dev
+```
+
+## Build and publish
+
+```bash
+dotnet build source/csr-util.slnx
+dotnet publish source/src/CsrUtil.Cli/CsrUtil.Cli.csproj -c Release -r linux-x64
+```
+
+OpenSSL must be available on `PATH`, or pass `--openssl-path /path/to/openssl`.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ easyrsa sign-req server app-dev
 
 ```bash
 dotnet build source/csr-util.slnx
-dotnet publish source/src/CsrUtil.Cli/CsrUtil.Cli.csproj -c Release -r linux-x64
+dotnet publish source/CsrUtil/CsrUtil.Cli/CsrUtil.Cli.csproj -c Release -r linux-x64
 ```
 
 OpenSSL must be available on `PATH`, or pass `--openssl-path /path/to/openssl`.

--- a/source/.editorconfig
+++ b/source/.editorconfig
@@ -7,9 +7,18 @@ charset = utf-8
 indent_style = space
 trim_trailing_whitespace = true
 end_of_line = lf
+insert_final_newline = true
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+tab_width = 4
 
 # C# files
 [*.cs]
+# Visual Studio sometimes guesses UTF-8 files with no BOM as something else
+charset = utf-8-bom
 
 #### C# Coding Conventions ####
 
@@ -44,7 +53,7 @@ csharp_style_conditional_delegate_call = true:suggestion
 
 # Modifier preferences
 csharp_prefer_static_local_function = true:suggestion
-csharp_preferred_modifier_order = public,private,internal,protected,file,static,extern,const,required,virtual,sealed,new,async,abstract,override,readonly,partial,unsafe,volatile:suggestion
+csharp_preferred_modifier_order = public,private,internal,protected,file,static,extern,const,required,virtual,sealed,new,async,abstract,override,readonly,partial,unsafe,volatile:warning
 csharp_style_prefer_readonly_struct = true:suggestion
 csharp_style_prefer_readonly_struct_member = true:suggestion
 
@@ -133,17 +142,28 @@ csharp_style_prefer_unbound_generic_type_in_nameof = true:suggestion
 csharp_prefer_static_anonymous_function = true:suggestion
 csharp_style_prefer_simple_property_accessors = true:warning
 
+[*.{csproj,targets,props}]
+# match Visual Studio behavior
+charset = utf-8-bom
+
+# Xml resource files
+[*.resx]
+# match Visual Studio behavior
+insert_final_newline = false
+trim_trailing_whitespace = false
+
+# Data serialization
+[*.{json,yaml,yml}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd,bat}]
+end_of_line = crlf
+
 # global preferences
 [*.{cs,vb}]
-
-#### Core EditorConfig Options ####
-
-# Indentation and spacing
-indent_size = 4
-tab_width = 4
-
-# New line preferences
-insert_final_newline = false
 
 #### .NET Coding Conventions ####
 

--- a/source/CsrUtil/CsrUtil.Cli/CsrCommands.cs
+++ b/source/CsrUtil/CsrUtil.Cli/CsrCommands.cs
@@ -1,0 +1,128 @@
+﻿using ConsoleAppFramework;
+
+namespace CsrUtil.Cli;
+
+public sealed class CsrCommands
+{
+    private const int DEFAULT_RSA_BITS = 2048;
+    private const int MINIMUM_RSA_BITS = 2048;
+    private const string DEFAULT_EC_CURVE = "prime256v1";
+    private const string DEFAULT_OPENSSL_PATH = "openssl";
+    private const string DEFAULT_OUTPUT_DIRECTORY = ".";
+
+    /// <summary>
+    /// Generate an OpenSSL private key and PKCS#10 CSR with DNS subjectAltName entries.
+    /// </summary>
+    /// <param name="keyType">-k, Key algorithm to generate: ec or rsa.</param>
+    /// <param name="rsaBits">RSA key size. Used only when --key-type rsa is selected.</param>
+    /// <param name="ecCurve">OpenSSL EC curve name. Used only when --key-type ec is selected.</param>
+    /// <param name="commonName">CSR subject common name. Defaults to the first subject name.</param>
+    /// <param name="outputDirectory">-o, Directory for generated files.</param>
+    /// <param name="prefix">-p, Output file prefix. Defaults to the first subject name with invalid filename characters replaced.</param>
+    /// <param name="opensslPath">Path to the openssl executable.</param>
+    /// <param name="overwrite">Replace existing key/CSR files.</param>
+    /// <param name="keepConfig">Keep the generated OpenSSL request config next to the output files.</param>
+    /// <param name="country">Optional subject country code.</param>
+    /// <param name="state">Optional subject state or province.</param>
+    /// <param name="locality">Optional subject locality.</param>
+    /// <param name="organization">Optional subject organization.</param>
+    /// <param name="organizationalUnit">Optional subject organizational unit.</param>
+    /// <param name="emailAddress">Optional subject email address.</param>
+    /// <param name="cancellationToken">Cancellation token provided by ConsoleAppFramework.</param>
+    /// <param name="subjectNames">DNS names to put into the CSR SAN extension. Comma-separated values are also accepted.</param>
+    [Command("generate")]
+    public async Task<int> GenerateAsync(
+        KeyType keyType = KeyType.Ec,
+        int rsaBits = DEFAULT_RSA_BITS,
+        string ecCurve = DEFAULT_EC_CURVE,
+        string? commonName = null,
+        string outputDirectory = DEFAULT_OUTPUT_DIRECTORY,
+        string? prefix = null,
+        string opensslPath = DEFAULT_OPENSSL_PATH,
+        bool overwrite = false,
+        bool keepConfig = false,
+        string? country = null,
+        string? state = null,
+        string? locality = null,
+        string? organization = null,
+        string? organizationalUnit = null,
+        string? emailAddress = null,
+        CancellationToken cancellationToken = default,
+        [Argument] params string[] subjectNames)
+    {
+        ArgumentNullException.ThrowIfNull(subjectNames);
+        try
+        {
+            List<string> names = NameParser.NormalizeSubjectNames(subjectNames);
+            if (names.Count == 0)
+            {
+                await Console.Error.WriteLineAsync("Specify at least one DNS subject name, for example: csr-util generate app.local api.app.local");
+                return 1;
+            }
+
+            if (keyType == KeyType.Rsa && rsaBits < MINIMUM_RSA_BITS)
+            {
+                await Console.Error.WriteLineAsync($"RSA keys must be at least {MINIMUM_RSA_BITS} bits. Pass --rsa-bits {MINIMUM_RSA_BITS} or higher.");
+                return 1;
+            }
+
+            string outputPath = Path.GetFullPath(outputDirectory);
+            string finalCommonName = string.IsNullOrWhiteSpace(commonName) ? names[0] : commonName.Trim();
+            NameParser.ThrowIfUnsafeConfigValue(finalCommonName, nameof(commonName));
+
+            string finalPrefix = string.IsNullOrWhiteSpace(prefix)
+                ? NameParser.SanitizeFileName(names[0])
+                : NameParser.SanitizeFileName(prefix.Trim());
+
+            if (string.IsNullOrWhiteSpace(finalPrefix))
+            {
+                await Console.Error.WriteLineAsync("Unable to derive an output file prefix. Pass --prefix explicitly.");
+                return 1;
+            }
+
+            CsrRequest request = new(
+                SubjectAlternativeNames: names,
+                CommonName: finalCommonName,
+                KeyType: keyType,
+                RsaBits: rsaBits,
+                EcCurve: ecCurve,
+                OutputDirectory: outputPath,
+                Prefix: finalPrefix,
+                OpenSslPath: opensslPath,
+                Overwrite: overwrite,
+                KeepConfig: keepConfig,
+                DistinguishedName: new DistinguishedNameOptions(
+                    Country: country,
+                    State: state,
+                    Locality: locality,
+                    Organization: organization,
+                    OrganizationalUnit: organizationalUnit,
+                    EmailAddress: emailAddress));
+
+            CsrGenerator generator = new();
+            CsrGenerationResult result = await generator.GenerateAsync(request, cancellationToken);
+
+            Console.WriteLine("CSR workflow completed.");
+            Console.WriteLine($"Private key: {result.PrivateKeyPath}");
+            Console.WriteLine($"CSR:         {result.CsrPath}");
+            if (result.OpenSslConfigPath is not null)
+            {
+                Console.WriteLine($"Config:      {result.OpenSslConfigPath}");
+            }
+
+            Console.WriteLine($"SANs:        {string.Join(", ", result.SubjectAlternativeNames)}");
+            Console.WriteLine("EasyRSA:     easyrsa import-req <csr-path> <short-name>");
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            await Console.Error.WriteLineAsync("Cancelled.");
+            return 130;
+        }
+        catch (Exception ex)
+        {
+            await Console.Error.WriteLineAsync(ex.Message);
+            return 1;
+        }
+    }
+}

--- a/source/CsrUtil/CsrUtil.Cli/CsrGenerationResult.cs
+++ b/source/CsrUtil/CsrUtil.Cli/CsrGenerationResult.cs
@@ -1,0 +1,7 @@
+﻿namespace CsrUtil.Cli;
+
+internal sealed record CsrGenerationResult(
+    string PrivateKeyPath,
+    string CsrPath,
+    string? OpenSslConfigPath,
+    IReadOnlyList<string> SubjectAlternativeNames);

--- a/source/CsrUtil/CsrUtil.Cli/CsrGenerator.cs
+++ b/source/CsrUtil/CsrUtil.Cli/CsrGenerator.cs
@@ -1,0 +1,109 @@
+﻿using System.Text;
+
+namespace CsrUtil.Cli;
+
+internal sealed class CsrGenerator
+{
+    public async Task<CsrGenerationResult> GenerateAsync(CsrRequest request, CancellationToken cancellationToken = default)
+    {
+        Directory.CreateDirectory(request.OutputDirectory);
+
+        string privateKeyPath = Path.Combine(request.OutputDirectory, $"{request.Prefix}.key.pem");
+        string csrPath = Path.Combine(request.OutputDirectory, $"{request.Prefix}.csr.pem");
+        string configPath = Path.Combine(request.OutputDirectory, $".{request.Prefix}.{Guid.NewGuid():N}.openssl.cnf");
+
+        EnsureWritable(privateKeyPath, request.Overwrite);
+        EnsureWritable(csrPath, request.Overwrite);
+
+        await EnsureOpenSslAvailableAsync(request.OpenSslPath, cancellationToken);
+
+        await GeneratePrivateKeyAsync(
+            request.OpenSslPath,
+            request.KeyType,
+            request.RsaBits,
+            request.EcCurve,
+            privateKeyPath,
+            cancellationToken);
+
+        await File.WriteAllTextAsync(
+            configPath,
+            OpenSslRequestConfig.Build(request),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            cancellationToken);
+
+        try
+        {
+            await OpenSslRunner.RunAsync(
+                request.OpenSslPath,
+                ["req", "-new", "-sha256", "-key", privateKeyPath, "-out", csrPath, "-config", configPath],
+                cancellationToken);
+        }
+        finally
+        {
+            if (!request.KeepConfig)
+            {
+                TryDelete(configPath);
+            }
+        }
+
+        return new CsrGenerationResult(
+            PrivateKeyPath: privateKeyPath,
+            CsrPath: csrPath,
+            OpenSslConfigPath: request.KeepConfig ? configPath : null,
+            SubjectAlternativeNames: request.SubjectAlternativeNames);
+    }
+
+    private static async Task EnsureOpenSslAvailableAsync(string opensslPath, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await OpenSslRunner.RunAsync(opensslPath, ["version"], cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new InvalidOperationException($"OpenSSL is required but could not be executed from '{opensslPath}': {ex.Message}", ex);
+        }
+    }
+
+    private static Task GeneratePrivateKeyAsync(
+        string opensslPath,
+        KeyType keyType,
+        int rsaBits,
+        string ecCurve,
+        string privateKeyPath,
+        CancellationToken cancellationToken)
+    {
+        return keyType switch
+        {
+            KeyType.Ec => OpenSslRunner.RunAsync(
+                opensslPath,
+                ["genpkey", "-algorithm", "EC", "-pkeyopt", $"ec_paramgen_curve:{ecCurve}", "-out", privateKeyPath],
+                cancellationToken),
+            KeyType.Rsa => OpenSslRunner.RunAsync(
+                opensslPath,
+                ["genpkey", "-algorithm", "RSA", "-pkeyopt", $"rsa_keygen_bits:{rsaBits}", "-out", privateKeyPath],
+                cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(keyType), keyType, "Unsupported key type.")
+        };
+    }
+
+    private static void EnsureWritable(string path, bool overwrite)
+    {
+        if (!overwrite && File.Exists(path))
+        {
+            throw new IOException($"File already exists: {path}. Pass --overwrite to replace it.");
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // Best effort cleanup. The generated CSR/key are still usable if temp config deletion fails.
+        }
+    }
+}

--- a/source/CsrUtil/CsrUtil.Cli/CsrRequest.cs
+++ b/source/CsrUtil/CsrUtil.Cli/CsrRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace CsrUtil.Cli;
+
+internal sealed record CsrRequest(
+    IReadOnlyList<string> SubjectAlternativeNames,
+    string CommonName,
+    KeyType KeyType,
+    int RsaBits,
+    string EcCurve,
+    string OutputDirectory,
+    string Prefix,
+    string OpenSslPath,
+    bool Overwrite,
+    bool KeepConfig,
+    DistinguishedNameOptions DistinguishedName);

--- a/source/CsrUtil/CsrUtil.Cli/CsrUtil.Cli.csproj
+++ b/source/CsrUtil/CsrUtil.Cli/CsrUtil.Cli.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <StripSymbols>true</StripSymbols>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ConsoleAppFramework" Version="5.7.13" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/source/CsrUtil/CsrUtil.Cli/DistinguishedNameOptions.cs
+++ b/source/CsrUtil/CsrUtil.Cli/DistinguishedNameOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace CsrUtil.Cli;
+
+internal sealed record DistinguishedNameOptions(
+    string? Country,
+    string? State,
+    string? Locality,
+    string? Organization,
+    string? OrganizationalUnit,
+    string? EmailAddress);

--- a/source/CsrUtil/CsrUtil.Cli/KeyType.cs
+++ b/source/CsrUtil/CsrUtil.Cli/KeyType.cs
@@ -1,0 +1,7 @@
+﻿namespace CsrUtil.Cli;
+
+public enum KeyType
+{
+    Ec,
+    Rsa
+}

--- a/source/CsrUtil/CsrUtil.Cli/NameParser.cs
+++ b/source/CsrUtil/CsrUtil.Cli/NameParser.cs
@@ -1,0 +1,95 @@
+﻿using System.Text;
+
+namespace CsrUtil.Cli;
+
+internal static class NameParser
+{
+    public static List<string> NormalizeSubjectNames(IEnumerable<string> rawValues)
+    {
+        List<string> names = [];
+        HashSet<string> seen = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (string rawValue in rawValues)
+        {
+            foreach (string part in rawValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (part.Length == 0)
+                {
+                    continue;
+                }
+
+                ThrowIfInvalidDnsSubjectName(part);
+                if (seen.Add(part))
+                {
+                    names.Add(part);
+                }
+            }
+        }
+
+        return names;
+    }
+
+    public static string SanitizeFileName(string value)
+    {
+        char[] invalidChars = Path.GetInvalidFileNameChars();
+        StringBuilder builder = new(value.Length);
+
+        foreach (char ch in value.Trim())
+        {
+            builder.Append(invalidChars.Contains(ch) ? '_' : ch);
+        }
+
+        return builder.ToString();
+    }
+
+    public static void ThrowIfUnsafeConfigValue(string value, string optionName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"{optionName} must not be empty.");
+        }
+
+        foreach (char ch in value)
+        {
+            if (char.IsControl(ch))
+            {
+                throw new ArgumentException($"{optionName} must not contain control characters.");
+            }
+        }
+    }
+
+    public static string EscapeOpenSslConfigValue(string value)
+    {
+        ThrowIfUnsafeConfigValue(value, "OpenSSL config value");
+
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("#", "\\#", StringComparison.Ordinal)
+            .Replace(";", "\\;", StringComparison.Ordinal);
+    }
+
+    private static void ThrowIfInvalidDnsSubjectName(string name)
+    {
+        ThrowIfUnsafeConfigValue(name, "subject name");
+
+        if (name.Length > 253)
+        {
+            throw new ArgumentException($"Subject name is too long: {name}");
+        }
+
+        if (name.Contains(' ') || name.Contains('\t'))
+        {
+            throw new ArgumentException($"Subject name must not contain whitespace: {name}");
+        }
+
+        if (name.Contains('/') || name.Contains('='))
+        {
+            throw new ArgumentException($"Subject name contains an unsafe character: {name}");
+        }
+
+        if (name[0] == '.' || name[^1] == '.')
+        {
+            throw new ArgumentException($"Subject name must not start or end with a dot: {name}");
+        }
+    }
+}

--- a/source/CsrUtil/CsrUtil.Cli/OpenSslRequestConfig.cs
+++ b/source/CsrUtil/CsrUtil.Cli/OpenSslRequestConfig.cs
@@ -1,0 +1,51 @@
+﻿using System.Text;
+
+namespace CsrUtil.Cli;
+
+internal static class OpenSslRequestConfig
+{
+    public static string Build(CsrRequest request)
+    {
+        StringBuilder builder = new();
+
+        builder.AppendLine("[ req ]");
+        builder.AppendLine("prompt = no");
+        builder.AppendLine("default_md = sha256");
+        builder.AppendLine("string_mask = utf8only");
+        builder.AppendLine("distinguished_name = req_distinguished_name");
+        builder.AppendLine("req_extensions = req_ext");
+        builder.AppendLine();
+
+        builder.AppendLine("[ req_distinguished_name ]");
+        AppendOptional(builder, "C", request.DistinguishedName.Country);
+        AppendOptional(builder, "ST", request.DistinguishedName.State);
+        AppendOptional(builder, "L", request.DistinguishedName.Locality);
+        AppendOptional(builder, "O", request.DistinguishedName.Organization);
+        AppendOptional(builder, "OU", request.DistinguishedName.OrganizationalUnit);
+        builder.AppendLine($"CN = {NameParser.EscapeOpenSslConfigValue(request.CommonName)}");
+        AppendOptional(builder, "emailAddress", request.DistinguishedName.EmailAddress);
+        builder.AppendLine();
+
+        builder.AppendLine("[ req_ext ]");
+        builder.AppendLine("subjectAltName = @alt_names");
+        builder.AppendLine();
+
+        builder.AppendLine("[ alt_names ]");
+        for (int i = 0; i < request.SubjectAlternativeNames.Count; i++)
+        {
+            builder.AppendLine($"DNS.{i + 1} = {NameParser.EscapeOpenSslConfigValue(request.SubjectAlternativeNames[i])}");
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendOptional(StringBuilder builder, string key, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        builder.AppendLine($"{key} = {NameParser.EscapeOpenSslConfigValue(value.Trim())}");
+    }
+}

--- a/source/CsrUtil/CsrUtil.Cli/OpenSslRunner.cs
+++ b/source/CsrUtil/CsrUtil.Cli/OpenSslRunner.cs
@@ -65,7 +65,8 @@ internal static class OpenSslRunner
         }
 
         StringBuilder message = new();
-        message.Append("openssl ");
+        message.Append(opensslPath);
+        message.Append(' ');
         message.Append(string.Join(' ', arguments));
         message.Append(" failed with exit code ");
         message.Append(process.ExitCode);

--- a/source/CsrUtil/CsrUtil.Cli/OpenSslRunner.cs
+++ b/source/CsrUtil/CsrUtil.Cli/OpenSslRunner.cs
@@ -1,0 +1,88 @@
+﻿using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+
+namespace CsrUtil.Cli;
+
+internal static class OpenSslRunner
+{
+    public static async Task RunAsync(string opensslPath, IReadOnlyList<string> arguments, CancellationToken cancellationToken)
+    {
+        ProcessStartInfo startInfo = new(opensslPath)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        foreach (string argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using Process process = new()
+        {
+            StartInfo = startInfo,
+            EnableRaisingEvents = false
+        };
+
+        try
+        {
+            process.Start();
+        }
+        catch (Win32Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to start '{opensslPath}'. Make sure OpenSSL is installed and on PATH, or pass --openssl-path.", ex);
+        }
+
+        using CancellationTokenRegistration cancellationRegistration = cancellationToken.Register(static state =>
+        {
+            Process runningProcess = (Process)state!;
+            try
+            {
+                if (!runningProcess.HasExited)
+                {
+                    runningProcess.Kill(entireProcessTree: true);
+                }
+            }
+            catch
+            {
+                // Ignore races with natural process exit.
+            }
+        }, process);
+
+        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        Task<string> stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        await process.WaitForExitAsync(cancellationToken);
+
+        string stdout = await stdoutTask;
+        string stderr = await stderrTask;
+
+        if (process.ExitCode == 0)
+        {
+            return;
+        }
+
+        StringBuilder message = new();
+        message.Append("openssl ");
+        message.Append(string.Join(' ', arguments));
+        message.Append(" failed with exit code ");
+        message.Append(process.ExitCode);
+        message.Append('.');
+
+        if (!string.IsNullOrWhiteSpace(stderr))
+        {
+            message.AppendLine();
+            message.Append(stderr.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(stdout))
+        {
+            message.AppendLine();
+            message.Append(stdout.Trim());
+        }
+
+        throw new InvalidOperationException(message.ToString());
+    }
+}

--- a/source/CsrUtil/CsrUtil.Cli/Program.cs
+++ b/source/CsrUtil/CsrUtil.Cli/Program.cs
@@ -1,0 +1,6 @@
+﻿using ConsoleAppFramework;
+using CsrUtil.Cli;
+
+ConsoleApp.ConsoleAppBuilder app = ConsoleApp.Create();
+app.Add<CsrCommands>();
+await app.RunAsync(args);

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
+  <PropertyGroup>
+
+    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+
+  </PropertyGroup>
+</Project>

--- a/source/csr-util.slnx
+++ b/source/csr-util.slnx
@@ -1,0 +1,7 @@
+<Solution>
+  <Folder Name="/Solution Items/">
+    <File Path=".editorconfig" />
+    <File Path="Directory.Build.props" />
+  </Folder>
+  <Project Path="CsrUtil/CsrUtil.Cli/CsrUtil.Cli.csproj" />
+</Solution>


### PR DESCRIPTION
This pull request introduces a new .NET 10 CLI tool called `csr-util` for generating private keys and PKCS#10 CSRs (Certificate Signing Requests) using OpenSSL, with a focus on usability for local development and integration with EasyRSA. The changes establish the initial codebase, including the CLI command, core logic, configuration, and supporting utilities, as well as project and documentation files.

**Key highlights of the pull request:**

### CLI Tool Implementation

* Implements the `csr-util` CLI app using ConsoleAppFramework, providing a `generate` command that wraps OpenSSL to create private keys and CSRs with DNS subjectAltName entries. The command supports EC (default, `prime256v1`) and RSA keys, custom output options, and multiple subject names. (`CsrCommands.cs`, `KeyType.cs`, `CsrRequest.cs`, `DistinguishedNameOptions.cs`, `CsrGenerationResult.cs`) [[1]](diffhunk://#diff-b23c2860955801953a6cec8886f98d0c49be739ac36bd4eb1ecd851662f126c7R1-R128) [[2]](diffhunk://#diff-dca043db1b267753494801cde2ad7558abf7a8fa98cb5526910e2ab2690c50baR1-R7) [[3]](diffhunk://#diff-517f68e030cfe651e5eeb7d31ac01fc87dfa43ca8eabc96fc9ea852e0ea0f211R1-R14) [[4]](diffhunk://#diff-927250c25ff480565e4c3df7f8d8590124826ab2a37e87e145f6a863dc0a6340R1-R9) [[5]](diffhunk://#diff-614114a16499e79df52d5080006de672895896b02496856bb49dbddc24d246afR1-R7)

* Adds the core logic for key and CSR generation, including:
  - OpenSSL process invocation and error handling (`OpenSslRunner.cs`)
  - OpenSSL config file generation for SANs and distinguished names (`OpenSslRequestConfig.cs`)
  - Input validation and normalization utilities for subject names and file names (`NameParser.cs`)
  - Ensures output files are not overwritten unless specified, and allows optional retention of the generated OpenSSL config file (`CsrGenerator.cs`) [[1]](diffhunk://#diff-f403025616cdca3412b2022e9aee6236dc1cdc235d1d0ef55639d9ac434e34f7R1-R88) [[2]](diffhunk://#diff-44de9d54e991cf85ca90cf0776d88e23311089d61ed926afd885f32aa0c286f1R1-R51) [[3]](diffhunk://#diff-61f0adab498d44106e387d0f136e78b92001d19587587025677416d9dca66456R1-R95) [[4]](diffhunk://#diff-515d0e54f2ef61d5bbe4f2dd4e434fc80c37b9d54e14aaf762e07f71cc9c874fR1-R109)

### Project Structure and Configuration

* Adds a .NET 10 SDK-style project file with Native AOT publishing enabled for fast, self-contained executables. References `ConsoleAppFramework`. (`CsrUtil.Cli.csproj`)

* Introduces an `.editorconfig` with conventions for C#, XML, JSON, and shell scripts, including indentation, charset, and Visual Studio compatibility adjustments. (`source/.editorconfig`) [[1]](diffhunk://#diff-7c7a25a878811d49c9a3d4e5d5ef479173724b7fed1b04e382f43a8a4fc99dbdR10-R21) [[2]](diffhunk://#diff-7c7a25a878811d49c9a3d4e5d5ef479173724b7fed1b04e382f43a8a4fc99dbdL47-R56) [[3]](diffhunk://#diff-7c7a25a878811d49c9a3d4e5d5ef479173724b7fed1b04e382f43a8a4fc99dbdL136-R166)

### Documentation

* Adds a `README.md` describing features, usage examples, output files, integration with EasyRSA, and build instructions.

---

**References:**  
[[1]](diffhunk://#diff-b23c2860955801953a6cec8886f98d0c49be739ac36bd4eb1ecd851662f126c7R1-R128) [[2]](diffhunk://#diff-dca043db1b267753494801cde2ad7558abf7a8fa98cb5526910e2ab2690c50baR1-R7) [[3]](diffhunk://#diff-517f68e030cfe651e5eeb7d31ac01fc87dfa43ca8eabc96fc9ea852e0ea0f211R1-R14) [[4]](diffhunk://#diff-927250c25ff480565e4c3df7f8d8590124826ab2a37e87e145f6a863dc0a6340R1-R9) [[5]](diffhunk://#diff-614114a16499e79df52d5080006de672895896b02496856bb49dbddc24d246afR1-R7) [[6]](diffhunk://#diff-f403025616cdca3412b2022e9aee6236dc1cdc235d1d0ef55639d9ac434e34f7R1-R88) [[7]](diffhunk://#diff-44de9d54e991cf85ca90cf0776d88e23311089d61ed926afd885f32aa0c286f1R1-R51) [[8]](diffhunk://#diff-61f0adab498d44106e387d0f136e78b92001d19587587025677416d9dca66456R1-R95) [[9]](diffhunk://#diff-515d0e54f2ef61d5bbe4f2dd4e434fc80c37b9d54e14aaf762e07f71cc9c874fR1-R109) [[10]](diffhunk://#diff-e7fedd854ec66f3880c486617a67a48aa9fe2c54eeb828e15f431a7237b35be4R1-R16) [[11]](diffhunk://#diff-7c7a25a878811d49c9a3d4e5d5ef479173724b7fed1b04e382f43a8a4fc99dbdR10-R21) [[12]](diffhunk://#diff-7c7a25a878811d49c9a3d4e5d5ef479173724b7fed1b04e382f43a8a4fc99dbdL47-R56) [[13]](diffhunk://#diff-7c7a25a878811d49c9a3d4e5d5ef479173724b7fed1b04e382f43a8a4fc99dbdL136-R166) [[14]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R59)